### PR TITLE
:heavy_minus_sign: fix: package.json 의존성 rollup 제거

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@rollup/rollup-darwin-arm64": "^4.14.3",
     "axios": "^1.6.8",
     "dotenv": "^16.4.5",
     "moment": "^2.30.1",


### PR DESCRIPTION
배포하는데 에러 떠서 dependencies 중 @rollup/rollup-darwin-arm64  제거했습니다.