### PR TITLE
포춘 api-Lanternid, 삭제된 연등 페이지

### DIFF
--- a/src/apis/api/fortune.js
+++ b/src/apis/api/fortune.js
@@ -1,9 +1,15 @@
 import { API } from "../../apis/utils";
 
-const fetchFortuneMessage = async () => {
+const fetchFortuneMessage = async Lanternid => {
+  const headers = {
+    "Content-Type": "application/json",
+    Lanternid: Lanternid
+  };
+
   try {
-    const response = await API.get("/api/lanterns/cookie");
-    console.log("API 응답 데이터:", response.data);
+    const response = await API.get("/api/lanterns/cookie", {
+      headers: headers
+    });
     return response.data.fortune;
   } catch (error) {
     console.error("API 요청 실패:", error);

--- a/src/components/common/templetes/initView/noLantern.jsx
+++ b/src/components/common/templetes/initView/noLantern.jsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import FixView from "../fixView/FixView";
+import styled from "styled-components";
+
+const TextWapper = styled.div`
+  flex-grow: 1;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  line-height: 1.5;
+  gap: 32px;
+`;
+
+const ImgWrapper = styled.img`
+  animation: ani_init_loading 2s linear infinite alternate;
+  @keyframes ani_init_loading {
+    0% {
+      transform: scale(1);
+    }
+    100% {
+      transform: scale(1.1);
+    }
+  }
+`;
+function NoLanternDetail() {
+  return (
+    <FixView>
+      <TextWapper>
+        <Link to="/">
+          <ImgWrapper src="/img/Lantern/Big_purple.png" width={80} />
+        </Link>
+        연등이 삭제되었습니다!
+        <br />
+        연꽃을 눌러 홈으로 이동해주세요 :)
+      </TextWapper>
+    </FixView>
+  );
+}
+
+export default NoLanternDetail;

--- a/src/components/common/templetes/initView/noLantern.jsx
+++ b/src/components/common/templetes/initView/noLantern.jsx
@@ -33,7 +33,7 @@ function NoLanternDetail() {
         <Link to="/">
           <ImgWrapper src="/img/Lantern/Big_purple.png" width={80} />
         </Link>
-        연등이 삭제되었습니다!
+        삭제된 연등입니다!
         <br />
         연꽃을 눌러 홈으로 이동해주세요 :)
       </TextWapper>

--- a/src/pages/fotrune/FortuneIntroPage.jsx
+++ b/src/pages/fotrune/FortuneIntroPage.jsx
@@ -47,7 +47,7 @@ function FortuneIntroPage() {
         window.location.href = `/fortuneLeaf/${detailId}`;
       }, 2000);
     }
-  }, [isLotusLightVisible]); // useEffect 괄호가 닫혀야 합니다.
+  }, [isLotusLightVisible]);
 
   const handleLotusClick = () => {
     setIsLotusLightVisible(true);

--- a/src/pages/fotrune/FortuneLeafPage.jsx
+++ b/src/pages/fotrune/FortuneLeafPage.jsx
@@ -61,7 +61,8 @@ function FortuneLeafPage() {
 
   useEffect(() => {
     const fetchData = async () => {
-      const message = await fetchFortuneMessage();
+      const Lanternid = localStorage.getItem("Lanternid");
+      const message = await fetchFortuneMessage(Lanternid);
       setFortuneMessage(message);
     };
 

--- a/src/pages/fotrune/MyDetailPage.jsx
+++ b/src/pages/fotrune/MyDetailPage.jsx
@@ -5,6 +5,7 @@ import html2canvas from "html2canvas";
 import FixView from "../../components/common/templetes/fixView/FixView";
 import MyBtn from "../../components/fortune/atoms/MyBtn";
 import { fetchLanternData } from "../../apis/api/lanternDetail";
+import NoLanternDetail from "../../components/common/templetes/initView/noLantern";
 
 const Container = styled.div`
   display: flex;
@@ -96,19 +97,23 @@ function MyDetailPage() {
           detailId={detailId}
         />
       )}
-      <FixView ref={FixViewRef}>
-        {" "}
-        {/* FixView에 ref 추가 */}
-        {lanternData && (
-          <DetailLanternWrapper>
-            <DetailLanternImg
-              src={`/img/lanternCard/${lanternData.lanternColor}_${lanternData.light_bool}.png`}
-            />
-            <TitleSec>{lanternData.nickname}</TitleSec>
-            <ContentSec>{lanternData.content}</ContentSec>
-          </DetailLanternWrapper>
-        )}
-      </FixView>
+      {lanternData ? (
+        <FixView ref={FixViewRef}>
+          {" "}
+          {/* FixView에 ref 추가 */}
+          {lanternData && (
+            <DetailLanternWrapper>
+              <DetailLanternImg
+                src={`/img/lanternCard/${lanternData.lanternColor}_${lanternData.light_bool}.png`}
+              />
+              <TitleSec>{lanternData.nickname}</TitleSec>
+              <ContentSec>{lanternData.content}</ContentSec>
+            </DetailLanternWrapper>
+          )}
+        </FixView>
+      ) : (
+        <NoLanternDetail />
+      )}
     </Container>
   );
 }

--- a/src/pages/lantern/LanternDetailPage.jsx
+++ b/src/pages/lantern/LanternDetailPage.jsx
@@ -20,6 +20,7 @@ import ReportAlertModal from "../../components/lanternWrite/organisms/ReportAler
 import ReportedAlertModal from "../../components/lanternWrite/organisms/ReportedAlertModal";
 import FixView from "../../components/common/templetes/fixView/FixView";
 import ModalBackground from "../../components/lanternWrite/atom/ModalBg";
+import NoLanternDetail from "../../components/common/templetes/initView/noLantern";
 
 function LanternDetailPage() {
   const [isInit, setIsInit] = useState(true);
@@ -132,77 +133,81 @@ function LanternDetailPage() {
   ) : (
     <FixView>
       <Header />
-      <LanternViewPaperContainer>
-        <LanternDotContainer onClick={openModal}>
-          <LanternDot src="/img/Lantern/Dot.png" />
-        </LanternDotContainer>
-        {/* 더보기 모달 */}
-        {modalOpen && (
-          <MoreModal
-            closeModal={closeModal}
-            openDeleteModal={openDeleteModal}
-            openReportModal={openReportModal}
-          />
-        )}
-        {/* 연등 삭제 모달*/}
-        {deleteModalOpen && (
-          <DeleteModal
-            closeDeleteModal={closeDeleteModal}
-            openPwModal={openPwModal}
-          />
-        )}
-        {/* 비밀번호 입력 모달 */}
-        {pwModalOpen && (
-          <>
-            <PwModal
-              openPwModal={openPwModal}
-              closePwModal={() => {
-                closePwModal();
-              }}
-              data={lanternData}
+      {lanternData ? (
+        <LanternViewPaperContainer>
+          <LanternDotContainer onClick={openModal}>
+            <LanternDot src="/img/Lantern/Dot.png" />
+          </LanternDotContainer>
+          {/* 더보기 모달 */}
+          {modalOpen && (
+            <MoreModal
+              closeModal={closeModal}
+              openDeleteModal={openDeleteModal}
+              openReportModal={openReportModal}
             />
-          </>
-        )}
+          )}
+          {/* 연등 삭제 모달*/}
+          {deleteModalOpen && (
+            <DeleteModal
+              closeDeleteModal={closeDeleteModal}
+              openPwModal={openPwModal}
+            />
+          )}
+          {/* 비밀번호 입력 모달 */}
+          {pwModalOpen && (
+            <>
+              <PwModal
+                openPwModal={openPwModal}
+                closePwModal={() => {
+                  closePwModal();
+                }}
+                data={lanternData}
+              />
+            </>
+          )}
 
-        {/* 신고 모달 */}
-        {reportModalOpen && (
-          <ReportModal
-            closeReportModal={closeReportModal}
-            openReportedModal={openReportedModal}
-            openIsReportedModal={openIsReportedModal}
-            detailId={detailId}
+          {/* 신고 모달 */}
+          {reportModalOpen && (
+            <ReportModal
+              closeReportModal={closeReportModal}
+              openReportedModal={openReportedModal}
+              openIsReportedModal={openIsReportedModal}
+              detailId={detailId}
+            />
+          )}
+          {/* 신고 완료 모달 */}
+          {reportedModalOpen && <ReportAlertModal />}
+          {/* 이미 신고한 게시글 모달 */}
+          {isReportedModalOpen && <ReportedAlertModal />}
+          <LanternViewPaperImg
+            src={
+              lanternData
+                ? `/img/lanternCard/${lanternData.lanternColor}_${lanternData.light_bool}.png`
+                : ""
+            }
           />
-        )}
-        {/* 신고 완료 모달 */}
-        {reportedModalOpen && <ReportAlertModal />}
-        {/* 이미 신고한 게시글 모달 */}
-        {isReportedModalOpen && <ReportedAlertModal />}
-        <LanternViewPaperImg
-          src={
-            lanternData
-              ? `/img/lanternCard/${lanternData.lanternColor}_${lanternData.light_bool}.png`
-              : ""
-          }
-        />
-        {/* ModalBackground 컴포넌트 사용 */}
-        {(deleteModalOpen ||
-          pwModalOpen ||
-          pwModalOpen ||
-          reportedModalOpen ||
-          isReportedModalOpen) && <ModalBackground />}
+          {/* ModalBackground 컴포넌트 사용 */}
+          {(deleteModalOpen ||
+            pwModalOpen ||
+            pwModalOpen ||
+            reportedModalOpen ||
+            isReportedModalOpen) && <ModalBackground />}
 
-        <LanternViewNickname>
-          {lanternData ? lanternData.nickname : ""}
-        </LanternViewNickname>
-        <LanternViewWish>
-          {lanternData ? lanternData.content : ""}
-        </LanternViewWish>
-        <LikeBtn
-          handleLikeClick={handleLikeClick}
-          isLiked={lanternData ? lanternData.is_liked : false}
-          LikeCount={lanternData ? lanternData.like_cnt : 0}
-        />
-      </LanternViewPaperContainer>
+          <LanternViewNickname>
+            {lanternData ? lanternData.nickname : ""}
+          </LanternViewNickname>
+          <LanternViewWish>
+            {lanternData ? lanternData.content : ""}
+          </LanternViewWish>
+          <LikeBtn
+            handleLikeClick={handleLikeClick}
+            isLiked={lanternData ? lanternData.is_liked : false}
+            LikeCount={lanternData ? lanternData.like_cnt : 0}
+          />
+        </LanternViewPaperContainer>
+      ) : (
+        <NoLanternDetail />
+      )}
     </FixView>
   );
 }

--- a/src/pages/lantern/LanternWritePage.jsx
+++ b/src/pages/lantern/LanternWritePage.jsx
@@ -69,14 +69,16 @@ function LanternWritePage() {
       });
 
       const detailId = response.id;
+      const Lanternid = response.id;
 
       // 포스트 성공 후 Recoil 상태 초기화
       setNickname("");
       setWish("");
       setPassword("");
       setClicked({});
-      console.log(response.id);
-      navigate(`/fortuneIntro/${detailId}`);
+      localStorage.setItem("Lanternid", Lanternid);
+
+      navigate(`/fortuneIntro/${detailId}`, {});
     } catch (error) {
       console.error("Failed to post lantern data:", error);
     }


### PR DESCRIPTION
- 포춘 api post시 Lanterid 값 헤더에 담아서 보내주기 (그 랜턴id값에 대한 포춘쿠키는 한번만 할당 / 한 사람이 여러개 작성하면 그 랜턴마다의 포춘쿠키 부여)
- 삭제된 연등 detail로 들어가면 나오는 화면 추가 (detail, mydetail)